### PR TITLE
mroonga: tests: prevents error if sourcedir is readonly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -229,8 +229,6 @@ storage/mroonga/vendor/groonga/src/grnslap
 storage/mroonga/vendor/groonga/src/groonga
 storage/mroonga/vendor/groonga/src/groonga-benchmark
 storage/mroonga/vendor/groonga/src/suggest/groonga-suggest-create-dataset
-storage/mroonga/mysql-test/mroonga/storage/r/information_schema_plugins.result
-storage/mroonga/mysql-test/mroonga/storage/r/variable_version.result
 # C and C++
 
 # Compiled Object files

--- a/storage/mroonga/CMakeLists.txt
+++ b/storage/mroonga/CMakeLists.txt
@@ -423,14 +423,6 @@ set(MRN_TEST_SUITE_DIR "${CMAKE_SOURCE_DIR}/mysql-test/suite/mroonga")
 if(NOT EXISTS "${MRN_TEST_SUITE_DIR}")
   set(MRN_TEST_SUITE_DIR "${PROJECT_SOURCE_DIR}/mysql-test/mroonga")
 endif()
-configure_file(
-  "${MRN_TEST_SUITE_DIR}/storage/r/information_schema_plugins.result.in"
-  "${MRN_TEST_SUITE_DIR}/storage/r/information_schema_plugins.result"
-  NEWLINE_STYLE LF)
-configure_file(
-  "${MRN_TEST_SUITE_DIR}/storage/r/variable_version.result.in"
-  "${MRN_TEST_SUITE_DIR}/storage/r/variable_version.result"
-  NEWLINE_STYLE LF)
 
 configure_file(
   "${PROJECT_SOURCE_DIR}/data/install.sql.in"

--- a/storage/mroonga/mysql-test/mroonga/storage/r/information_schema_plugins.result
+++ b/storage/mroonga/mysql-test/mroonga/storage/r/information_schema_plugins.result
@@ -1,0 +1,4 @@
+select PLUGIN_NAME, PLUGIN_TYPE
+from information_schema.plugins where plugin_name = "Mroonga";
+PLUGIN_NAME	PLUGIN_TYPE
+Mroonga	STORAGE ENGINE

--- a/storage/mroonga/mysql-test/mroonga/storage/r/information_schema_plugins.result.in
+++ b/storage/mroonga/mysql-test/mroonga/storage/r/information_schema_plugins.result.in
@@ -1,4 +1,0 @@
-select PLUGIN_NAME, PLUGIN_VERSION, PLUGIN_TYPE
-from information_schema.plugins where plugin_name = "Mroonga";
-PLUGIN_NAME	PLUGIN_VERSION	PLUGIN_TYPE
-Mroonga	@MRN_PLUGIN_VERSION@	STORAGE ENGINE

--- a/storage/mroonga/mysql-test/mroonga/storage/r/variable_version.result
+++ b/storage/mroonga/mysql-test/mroonga/storage/r/variable_version.result
@@ -1,3 +1,3 @@
 show variables like 'mroonga_version';
 Variable_name	Value
-mroonga_version	@MRN_VERSION@
+mroonga_version	X.YY

--- a/storage/mroonga/mysql-test/mroonga/storage/t/information_schema_plugins.test
+++ b/storage/mroonga/mysql-test/mroonga/storage/t/information_schema_plugins.test
@@ -16,7 +16,7 @@
 
 --source ../../include/mroonga/have_mroonga.inc
 
-select PLUGIN_NAME, PLUGIN_VERSION, PLUGIN_TYPE
+select PLUGIN_NAME, PLUGIN_TYPE
        from information_schema.plugins where plugin_name = "Mroonga";
 
 --source ../../include/mroonga/have_mroonga_deinit.inc

--- a/storage/mroonga/mysql-test/mroonga/storage/t/variable_version.test
+++ b/storage/mroonga/mysql-test/mroonga/storage/t/variable_version.test
@@ -17,6 +17,7 @@
 --source ../../include/mroonga/have_mroonga.inc
 
 # show variables like 'groonga%';
+--replace_regex /[0-9]+\.[0-9]+/X.YY/
 show variables like 'mroonga_version';
 
 --source ../../include/mroonga/have_mroonga_deinit.inc


### PR DESCRIPTION
An out-of-tree build where the the source is readonly results the
following cmake error. The source tree for out-of-tree builds
should be immutable.

As the version number isn't of particular importance remove the
dependence of the tests finding the exact same version.

CMake Error: Could not open file for write in copy operation /source/storage/mroonga/mysql-test/mroonga/storage/r/information_schema_plugins.result.tmp
CMake Error: : System Error: Read-only file system
CMake Error at storage/mroonga/CMakeLists.txt:437 (configure_file):
  configure_file Problem configuring file

CMake Error: Could not open file for write in copy operation /source/storage/mroonga/mysql-test/mroonga/storage/r/variable_version.result.tmp
CMake Error: : System Error: Read-only file system
CMake Error at storage/mroonga/CMakeLists.txt:441 (configure_file):
  configure_file Problem configuring file

Moved here from https://github.com/MariaDB/server/pull/655 as requested.

I submit this under the MCA.